### PR TITLE
make AssertionFailedError harder to rescue

### DIFF
--- a/lib/solid_assert/assertion_failed_error.rb
+++ b/lib/solid_assert/assertion_failed_error.rb
@@ -1,3 +1,3 @@
 module SolidAssert
-  class AssertionFailedError < StandardError ; end
+  class AssertionFailedError < Exception ; end
 end


### PR DESCRIPTION
would be nice to not be able to `rescue => e` an `AssertionFailedError`...